### PR TITLE
Update and Finish TODO's

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Installation
 
     * [See the Apache FileVault project page](http://jackrabbit.apache.org/filevault/)
 
-1. **With Homebrew on Mac
+1. **With Homebrew on Mac**
 
-    * [See Hombrew Documentation](brew.sh) `brew install vault-cli`
+    * `brew install vault-cli` [See Hombrew Documentation](brew.sh) 
 
 **Make sure it's accessible on the command line.**
 
@@ -44,14 +44,14 @@ From your ```jcr_root``` folder, run the vlt-watch tool.
 
 ```
 Watch the filesystem for changes and sync them with the remote JCR.
-Usage: vlt-watch
+Usage: vlt-watch.js
 
 Options:
-  --help          Print usage and quit.                           
-  -h, --host      Remote host                                       [default: "http://localhost:4502"]
-  -u, --username  Username                                          [default: "admin"]
-  -p, --password  Password                                          [default: "admin"]
-  -f, --filter    The path to your META-INF/vault/filter.xml file.  [default: ""]
-  -c, --clean     Removes the .vlt files on exit.
-  -r, --jcr_root  The Path of the jcr_root folder.                  [default: "."]
+  -h, --host      Remote host                 [default: "http://localhost:4502"]
+  -u, --username  Username                                    [default: "admin"]
+  -p, --password  Password                                    [default: "admin"]
+  -r, --jcr_root  The path to your jcr_root folder                [default: "."]
+  -c, --clean     Clean up .vlt files on exit                          [boolean]
+  -f, --filter    The path to your META-INF/vault/filter.xml file. [default: ""]
+  -H, --help      Print usage and quit.
 ```

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Installation
 
     * [Follow the Adobe Experience Manager docs](http://dev.day.com/docs/en/crx/current/how_to/how_to_use_the_vlttool.html#Installing%20the%20vlt%20tool)
 
-1. **From the JackRabbit FileFault project**
+1. **From the JackRabbit FileVault project**
 
     * [See the Apache FileVault project page](http://jackrabbit.apache.org/filevault/)
 
+1. **With Homebrew on Mac
+
+    * [See Hombrew Documentation](brew.sh) `brew install vault-cli`
 
 **Make sure it's accessible on the command line.**
 
@@ -26,7 +29,7 @@ Installation
 
 ### Step 2: Download and install the vlt-watch tool
 
-(Install Node.js first if you haven't already)
+(Install [Node.js](https://nodejs.org) first if you haven't already)
 
 ```
 # npm install -g vlt-watch

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ vlt-watch
 
 vlt-watch watches a local folder for changes as you work, automatically adding and removing files from a remote JCR so you don't have to think about it.
 
+This is a lightweight alternative to [Brackets](http://brackets.io/) for AEM development.
+
 Installation
 ------------
 
@@ -40,8 +42,6 @@ Usage
 
 From your ```jcr_root``` folder, run the vlt-watch tool.
 
-todo: Allow specifying a path to the jcr_root folder, default shoudl be ```.```.
-
 ```
 Watch the filesystem for changes and sync them with the remote JCR.
 Usage: vlt-watch
@@ -52,4 +52,6 @@ Options:
   -u, --username  Username                                          [default: "admin"]
   -p, --password  Password                                          [default: "admin"]
   -f, --filter    The path to your META-INF/vault/filter.xml file.  [default: ""]
+  -c, --clean     Removes the .vlt files on exit.
+  -r, --jcr_root  The Path of the jcr_root folder.                  [default: "."]
 ```

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "description": "Watch a directory for changes, and use vault to update your remote JCR root.",
   "main": "vlt-watch.js",
   "author": "Jay Proulx",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jayproulx/vlt-watch.git"
+  },
   "license": "ISC",
   "bin": {
     "vlt-watch": "vlt-watch.js"
   },
   "dependencies": {
-    "chokidar": "~0.8.2",
-    "yargs": "~1.2.1",
-    "colors": "~0.6.2"
+    "chokidar": "~1.6.0",
+    "yargs": "~5.0.0",
+    "colors": "~1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "chokidar": "~1.6.0",
-    "yargs": "~5.0.0",
-    "colors": "~1.1.2"
+    "colors": "~1.1.2",
+    "glob": "^7.0.6",
+    "readline": "^1.3.0",
+    "yargs": "~5.0.0"
   }
 }


### PR DESCRIPTION
Use newer versions of everything to avoid having to download XCode on Mac.
Also I finished the todo items:
- Allow specifying jrc_root directory from command line
- Optionally cleanup the .vlt files on exit. Note that deleting these files make the next checkout on startup slower since these files contain synchronization information.
- Add color to the output.