### PR TITLE
Allow larger content folders

### DIFF
--- a/vlt-watch.js
+++ b/vlt-watch.js
@@ -101,7 +101,7 @@ var VltWatch = {
 	},
 
 	checkout: function ( callback ) {
-		VltWatch.exec( VltWatch.commands.checkout, undefined, callback );
+		VltWatch.exec( VltWatch.commands.checkout, { "maxBuffer": 1000000 }, callback );
 	},
 
 	add: function ( path, callback ) {


### PR DESCRIPTION
Increase the exec stdout buffer size to allow for bigger jcr_root folders.
